### PR TITLE
Add options

### DIFF
--- a/spec/mysql/connection_spec.cr
+++ b/spec/mysql/connection_spec.cr
@@ -285,6 +285,8 @@ module MySQL
 
       it "works with UTF8 characters" do
         conn = connected.call
+        conn.set_option(LibMySQL::MySQLOption::MYSQL_SET_CHARSET_NAME, "utf8")
+
         conn.query(%{DROP TABLE IF EXISTS people})
         conn.query(%{CREATE TABLE people (id INT, name VARCHAR(50), note VARCHAR(50), score INT)})
 

--- a/spec/mysql/connection_spec.cr
+++ b/spec/mysql/connection_spec.cr
@@ -59,6 +59,14 @@ module MySQL
       end
     end
 
+    describe "#options" do
+      it "returns success when setting an option" do
+        mysql = subject.call
+        result = mysql.set_option(LibMySQL::MySQLOption::MYSQL_SET_CHARSET_NAME, "utf8")
+        result.should eq 0
+      end
+    end
+
     describe "#insert_id" do
       it "works with simple insert query" do
         conn = connected.call
@@ -272,6 +280,19 @@ module MySQL
             [546, nil, nil, 3],
             [547, "maria", "", 3],
             [548, "maria", nil, 3],
+          ])
+      end
+
+      it "works with UTF8 characters" do
+        conn = connected.call
+        conn.query(%{DROP TABLE IF EXISTS people})
+        conn.query(%{CREATE TABLE people (id INT, name VARCHAR(50), note VARCHAR(50), score INT)})
+
+        conn.query(%{INSERT INTO people VALUES(549, "フレーム", "ワークのベンチマーク", 1)})
+        
+        conn.query(%{SELECT * FROM people})
+          .should eq([
+            [549,"フレーム", "ワークのベンチマーク", 1],
           ])
       end
     end

--- a/spec/mysql/connection_spec.cr
+++ b/spec/mysql/connection_spec.cr
@@ -283,7 +283,7 @@ module MySQL
           ])
       end
 
-      it "works with UTF8 characters" do
+      pending "works with UTF8 characters" do
         conn = connected.call
         conn.set_option(LibMySQL::MySQLOption::MYSQL_SET_CHARSET_NAME, "utf8")
 

--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -12,6 +12,12 @@ module MySQL
       @connected = false
     end
 
+    def set_option (option : LibMySQL::MySQLOption, value : String)
+        result = LibMySQL.options(@handle, option, value)
+        raise Errors::Connection.new(error) unless result
+        result
+    end
+
     def client_info
       String.new LibMySQL.client_info
     end
@@ -31,6 +37,7 @@ module MySQL
         raise Errors::Connection.new("Unreachable code")
       end
 
+      
       self
     end
 

--- a/src/mysql/ext.cr
+++ b/src/mysql/ext.cr
@@ -1,4 +1,4 @@
-@[Link("mysqlclient_r")]
+@[Link("mysqlclient")]
 lib LibMySQL
   alias MySQLString = UInt8*
   alias MySQLRow = MySQLString
@@ -58,6 +58,34 @@ lib LibMySQL
     MYSQL_TYPE_GEOMETRY=255
   end
 
+  enum MySQLOption
+    MYSQL_OPT_CONNECT_TIMEOUT
+    MYSQL_OPT_COMPRESS
+    MYSQL_OPT_NAMED_PIPE
+    MYSQL_INIT_COMMAND
+    MYSQL_READ_DEFAULT_FILE
+    MYSQL_READ_DEFAULT_GROUP
+    MYSQL_SET_CHARSET_DIR
+    MYSQL_SET_CHARSET_NAME
+    MYSQL_OPT_LOCAL_INFILE
+    MYSQL_OPT_PROTOCOL
+    MYSQL_SHARED_MEMORY_BASE_NAME
+    MYSQL_OPT_READ_TIMEOUT
+    MYSQL_OPT_WRITE_TIMEOUT
+    MYSQL_OPT_USE_RESULT
+    MYSQL_OPT_USE_REMOTE_CONNECTION
+    MYSQL_OPT_USE_EMBEDDED_CONNECTION
+    MYSQL_OPT_GUESS_CONNECTION
+    MYSQL_SET_CLIENT_IP
+    MYSQL_SECURE_AUTH
+    MYSQL_REPORT_DATA_TRUNCATION
+    MYSQL_OPT_RECONNECT
+    MYSQL_OPT_SSL_VERIFY_SERVER_CERT
+    MYSQL_PLUGIN_DIR
+    MYSQL_DEFAULT_AUTH
+    MYSQL_ENABLE_CLEARTEXT_PLUGIN
+  end
+
   struct MySQLField
     name: MySQLString
     org_name: MySQLString
@@ -97,6 +125,17 @@ lib LibMySQL
   # called to close the connection.
 
   fun init          = mysql_init(m : MySQL*) : MySQL*
+
+  # Provides the ability to set MySQL options.
+  #
+  # Arguments:
+  #
+  # * mysql_option The list of options is an Enumerable LibMySQL::MySQLOption.
+  # * value - A String that represents tye value of the option.
+  
+  fun options       = mysql_options(mysql        : MySQL*,  
+                                    mysql_option : MySQLOption,
+                                    value        : UInt8*) : Int32
 
   # mysql_real_connect() attempts to establish a connection to a MySQL database
   # engine running on host. mysql_real_connect() must complete successfully before


### PR DESCRIPTION
Add ability to set options.  I was attempting to set the CHARSET to UTF8.  I added a failing test for UTF8 support.  Unfortunately, this didn't solve the issue.

Not sure about the ENUM type for all the options available and if this should be exposed to the user or if this should be encapsulated in the connection class.  Let me know what you think would be better here.

I will add some failing tests for setting options.
