### PR TITLE
Fix Datetime format bug

### DIFF
--- a/spec/mysql/query_spec.cr
+++ b/spec/mysql/query_spec.cr
@@ -68,7 +68,7 @@ module MySQL
       it "works with time" do
         Query.new(%{SELECT :a}, {
                     "a" => Time::Format.new("%F %T").parse("2005-03-27 02:00:00", Time::Kind::Utc),
-                  }).to_mysql.should eq(%{SELECT '2005-03-27 02:00:00 UTC'})
+                  }).to_mysql.should eq(%{SELECT '2005-03-27 02:00:00'})
       end
 
       it "works with date (kinda)" do

--- a/src/mysql/types.cr
+++ b/src/mysql/types.cr
@@ -67,7 +67,7 @@ module MySQL
       end
 
       def to_mysql
-        "'#{(value as Time).to_utc.to_s}'"
+        %{'#{(value as Time).to_utc.to_s("%F %T")}'}
       end
     end
 


### PR DESCRIPTION
MySQL DATETIME format is `YYYY-MM-DD hh:mm:ss`.
https://dev.mysql.com/doc/refman/5.6/en/datetime.html

But, `Time#to_s` makes `YYYY-MM-DD hh:mm:ss +TZ`.
So, we can use `Time#to_s("%F %T")` :+1: 
